### PR TITLE
quizQuestions

### DIFF
--- a/frontend/src/api/quiz.ts
+++ b/frontend/src/api/quiz.ts
@@ -81,10 +81,159 @@ export const skipQuiz = async (): Promise<ProfileResponse> => {
   return response.data;
 };
 
+// ==================== ADMIN API Types ====================
+
+export type RoleType = 'LEADER' | 'PLANNER' | 'EXPERT' | 'CREATIVE' | 'COMMUNICATOR' | 'TEAM_PLAYER' | 'CHALLENGER';
+
+export interface QuizOptionAdmin {
+  optionId: number;
+  optionText: string;
+  orderIndex: number;
+  roleWeights: Record<RoleType, number>;
+}
+
+export interface QuizQuestionAdmin {
+  questionId: number;
+  questionText: string;
+  orderIndex: number;
+  active: boolean;
+  options: QuizOptionAdmin[];
+}
+
+export interface CreateQuestionRequest {
+  questionText: string;
+  orderIndex: number;
+  options: CreateOptionRequest[];
+}
+
+export interface CreateOptionRequest {
+  optionText: string;
+  orderIndex: number;
+  roleWeights: Record<RoleType, number>;
+}
+
+export interface UpdateQuestionRequest {
+  questionText: string;
+  orderIndex: number;
+  active?: boolean;
+  options?: UpdateOptionRequest[];
+}
+
+export interface UpdateOptionRequest {
+  optionText: string;
+  orderIndex: number;
+  roleWeights: Record<RoleType, number>;
+}
+
+// ==================== ADMIN API Calls ====================
+
+/**
+ * Get all quiz questions (admin only).
+ * GET /api/admin/quiz/questions
+ */
+export const getAdminQuestions = async (): Promise<QuizQuestionAdmin[]> => {
+  const response = await axios.get<QuizQuestionAdmin[]>('/admin/quiz/questions');
+  return response.data;
+};
+
+/**
+ * Get a single question (admin only).
+ * GET /api/admin/quiz/questions/{id}
+ */
+export const getAdminQuestion = async (id: number): Promise<QuizQuestionAdmin> => {
+  const response = await axios.get<QuizQuestionAdmin>(`/admin/quiz/questions/${id}`);
+  return response.data;
+};
+
+/**
+ * Create a new quiz question (admin only).
+ * POST /api/admin/quiz/questions
+ */
+export const createAdminQuestion = async (request: CreateQuestionRequest): Promise<QuizQuestionAdmin> => {
+  const response = await axios.post<QuizQuestionAdmin>('/admin/quiz/questions', request);
+  return response.data;
+};
+
+/**
+ * Update a quiz question (admin only).
+ * PUT /api/admin/quiz/questions/{id}
+ */
+export const updateAdminQuestion = async (id: number, request: UpdateQuestionRequest): Promise<QuizQuestionAdmin> => {
+  const response = await axios.put<QuizQuestionAdmin>(`/admin/quiz/questions/${id}`, request);
+  return response.data;
+};
+
+/**
+ * Delete (deactivate) a quiz question (admin only).
+ * DELETE /api/admin/quiz/questions/{id}
+ */
+export const deleteAdminQuestion = async (id: number): Promise<void> => {
+  await axios.delete(`/admin/quiz/questions/${id}`);
+};
+
+/**
+ * Update a quiz option (admin only).
+ * PUT /api/admin/quiz/questions/{questionId}/options/{optionId}
+ */
+export const updateAdminOption = async (
+  questionId: number,
+  optionId: number,
+  request: UpdateOptionRequest
+): Promise<QuizOptionAdmin> => {
+  const response = await axios.put<QuizOptionAdmin>(
+    `/admin/quiz/questions/${questionId}/options/${optionId}`,
+    request
+  );
+  return response.data;
+};
+
+/**
+ * Delete a quiz option (admin only).
+ * DELETE /api/admin/quiz/questions/{questionId}/options/{optionId}
+ */
+export const deleteAdminOption = async (questionId: number, optionId: number): Promise<void> => {
+  await axios.delete(`/admin/quiz/questions/${questionId}/options/${optionId}`);
+};
+
+/**
+ * Quiz Configuration Types
+ */
+export interface QuizConfig {
+  id: number;
+  selectedQuestionIds: number[];
+  configKey: string;
+}
+
+/**
+ * Get quiz configuration (admin only).
+ * GET /api/admin/quiz/config
+ */
+export const getQuizConfig = async (): Promise<QuizConfig> => {
+  const response = await axios.get<QuizConfig>('/admin/quiz/config');
+  return response.data;
+};
+
+/**
+ * Update quiz configuration (admin only).
+ * PUT /api/admin/quiz/config
+ */
+export const updateQuizConfig = async (selectedQuestionIds: number[]): Promise<QuizConfig> => {
+  const response = await axios.put<QuizConfig>('/admin/quiz/config', { selectedQuestionIds });
+  return response.data;
+};
+
 export default {
   getQuiz,
   submitQuiz,
   getProfile,
   getOnboardingStatus,
   skipQuiz,
+  // Admin functions
+  getAdminQuestions,
+  getAdminQuestion,
+  createAdminQuestion,
+  updateAdminQuestion,
+  deleteAdminQuestion,
+  updateAdminOption,
+  deleteAdminOption,
 };

--- a/frontend/src/components/admin/QuizManagement.tsx
+++ b/frontend/src/components/admin/QuizManagement.tsx
@@ -1,0 +1,529 @@
+import React, { useState, useEffect } from 'react';
+import {
+  getAdminQuestions,
+  createAdminQuestion,
+  updateAdminQuestion,
+  deleteAdminQuestion,
+  updateAdminOption,
+  deleteAdminOption,
+  getQuizConfig,
+  updateQuizConfig,
+  QuizQuestionAdmin,
+  CreateQuestionRequest,
+  UpdateQuestionRequest,
+  RoleType,
+  QuizConfig,
+} from '../../api/quiz';
+import { useToast } from '../../context/ToastContext';
+import {
+  Plus,
+  Edit,
+  Trash2,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+  AlertCircle,
+  CheckCircle,
+  X,
+  XCircle,
+  Settings,
+  Save,
+} from 'lucide-react';
+import QuizQuestionEditor from './QuizQuestionEditor';
+
+const ROLE_TYPES: RoleType[] = ['LEADER', 'PLANNER', 'EXPERT', 'CREATIVE', 'COMMUNICATOR', 'TEAM_PLAYER', 'CHALLENGER'];
+const ROLE_LABELS: Record<RoleType, string> = {
+  LEADER: 'Leader',
+  PLANNER: 'Planner',
+  EXPERT: 'Expert',
+  CREATIVE: 'Creative',
+  COMMUNICATOR: 'Communicator',
+  TEAM_PLAYER: 'Team Player',
+  CHALLENGER: 'Challenger',
+};
+
+const QuizManagement: React.FC = () => {
+  const { showSuccess, showError } = useToast();
+  const [questions, setQuestions] = useState<QuizQuestionAdmin[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expandedQuestions, setExpandedQuestions] = useState<Set<number>>(new Set());
+  const [showEditor, setShowEditor] = useState(false);
+  const [editingQuestion, setEditingQuestion] = useState<QuizQuestionAdmin | null>(null);
+  const [editingOptionId, setEditingOptionId] = useState<number | null>(null);
+  const [config, setConfig] = useState<QuizConfig | null>(null);
+  const [configLoading, setConfigLoading] = useState(true);
+  const [selectedQuestionIds, setSelectedQuestionIds] = useState<Set<number>>(new Set());
+  const [savingConfig, setSavingConfig] = useState(false);
+
+  useEffect(() => {
+    loadQuestions();
+    loadConfig();
+  }, []);
+
+  const loadQuestions = async () => {
+    try {
+      setLoading(true);
+      const data = await getAdminQuestions();
+      setQuestions(data);
+    } catch (error) {
+      console.error('Failed to load questions:', error);
+      showError('Failed to load quiz questions');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadConfig = async () => {
+    try {
+      setConfigLoading(true);
+      const data = await getQuizConfig();
+      setConfig(data);
+      // Initialize selected question IDs from config
+      setSelectedQuestionIds(new Set(data.selectedQuestionIds || []));
+    } catch (error) {
+      console.error('Failed to load config:', error);
+      showError('Failed to load quiz configuration');
+    } finally {
+      setConfigLoading(false);
+    }
+  };
+
+  const handleSaveConfig = async () => {
+    try {
+      setSavingConfig(true);
+      const selectedIds = Array.from(selectedQuestionIds);
+      const updated = await updateQuizConfig(selectedIds);
+      setConfig(updated);
+      showSuccess('Quiz configuration updated successfully');
+    } catch (error) {
+      console.error('Failed to save config:', error);
+      showError('Failed to save quiz configuration');
+    } finally {
+      setSavingConfig(false);
+    }
+  };
+
+  const handleToggleQuestion = (questionId: number) => {
+    const newSelected = new Set(selectedQuestionIds);
+    if (newSelected.has(questionId)) {
+      newSelected.delete(questionId);
+    } else {
+      newSelected.add(questionId);
+    }
+    setSelectedQuestionIds(newSelected);
+  };
+
+  const handleSelectAll = () => {
+    const allActiveIds = new Set(activeQuestions.map(q => q.questionId));
+    setSelectedQuestionIds(allActiveIds);
+  };
+
+  const handleDeselectAll = () => {
+    setSelectedQuestionIds(new Set());
+  };
+
+  const handleCreateQuestion = () => {
+    setEditingQuestion(null);
+    setEditingOptionId(null); // Ensure we're creating a question, not editing an option
+    setShowEditor(true);
+  };
+
+  const handleEditQuestion = (question: QuizQuestionAdmin) => {
+    setEditingQuestion(question);
+    setEditingOptionId(null); // Ensure we're editing the question, not an option
+    setShowEditor(true);
+  };
+
+  const handleDeleteQuestion = async (questionId: number) => {
+    if (!window.confirm('Are you sure you want to delete this question? It will be deactivated.')) {
+      return;
+    }
+
+    try {
+      await deleteAdminQuestion(questionId);
+      showSuccess('Question deleted successfully');
+      loadQuestions();
+    } catch (error) {
+      console.error('Failed to delete question:', error);
+      showError('Failed to delete question');
+    }
+  };
+
+  const handleSaveQuestion = async (questionData: CreateQuestionRequest | UpdateQuestionRequest) => {
+    try {
+      if (editingQuestion) {
+        await updateAdminQuestion(editingQuestion.questionId, questionData as UpdateQuestionRequest);
+        showSuccess('Question updated successfully');
+      } else {
+        await createAdminQuestion(questionData as CreateQuestionRequest);
+        showSuccess('Question created successfully');
+      }
+      setShowEditor(false);
+      setEditingQuestion(null);
+      setEditingOptionId(null);
+      loadQuestions();
+    } catch (error) {
+      console.error('Failed to save question:', error);
+      const errorMessage = error instanceof Error ? error.message : 'Failed to save question';
+      showError(errorMessage);
+    }
+  };
+
+  const toggleExpand = (questionId: number) => {
+    const newExpanded = new Set(expandedQuestions);
+    if (newExpanded.has(questionId)) {
+      newExpanded.delete(questionId);
+    } else {
+      newExpanded.add(questionId);
+    }
+    setExpandedQuestions(newExpanded);
+  };
+
+  const handleEditOption = async (questionId: number, optionId: number) => {
+    const question = questions.find(q => q.questionId === questionId);
+    if (!question) return;
+    
+    const option = question.options.find(opt => opt.optionId === optionId);
+    if (!option) return;
+    
+    setEditingQuestion(question);
+    setEditingOptionId(optionId);
+    setShowEditor(true);
+  };
+
+  const handleSaveOption = async (questionId: number, optionId: number, optionData: any) => {
+    try {
+      await updateAdminOption(questionId, optionId, optionData);
+      showSuccess('Option updated successfully');
+      setShowEditor(false);
+      setEditingQuestion(null);
+      setEditingOptionId(null);
+      loadQuestions();
+    } catch (error) {
+      console.error('Failed to save option:', error);
+      showError('Failed to save option');
+    }
+  };
+
+  const handleDeleteOption = async (questionId: number, optionId: number) => {
+    if (!window.confirm('Are you sure you want to delete this option?')) {
+      return;
+    }
+
+    try {
+      await deleteAdminOption(questionId, optionId);
+      showSuccess('Option deleted successfully');
+      loadQuestions();
+    } catch (error) {
+      console.error('Failed to delete option:', error);
+      showError('Failed to delete option');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="w-8 h-8 animate-spin text-primary-600" />
+      </div>
+    );
+  }
+
+  const activeQuestions = questions.filter(q => q.active);
+  const inactiveQuestions = questions.filter(q => !q.active);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">Quiz Management</h2>
+          <p className="text-gray-600 mt-1">Manage quiz questions and their role weights</p>
+        </div>
+        <button
+          onClick={handleCreateQuestion}
+          className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-xl hover:bg-primary-700 transition-colors"
+        >
+          <Plus className="w-5 h-5" />
+          Create Question
+        </button>
+      </div>
+
+      {/* Quiz Configuration */}
+      <div className="bg-white rounded-xl border-2 border-gray-200 p-6">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-3">
+            <Settings className="w-6 h-6 text-primary-600" />
+            <h3 className="text-lg font-semibold text-gray-900">Quiz Configuration</h3>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleSelectAll}
+              disabled={configLoading || savingConfig || activeQuestions.length === 0}
+              className="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Select All
+            </button>
+            <button
+              onClick={handleDeselectAll}
+              disabled={configLoading || savingConfig || selectedQuestionIds.size === 0}
+              className="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Deselect All
+            </button>
+            <button
+              onClick={handleSaveConfig}
+              disabled={configLoading || savingConfig}
+              className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {savingConfig ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Save className="w-4 h-4" />
+              )}
+              Save
+            </button>
+          </div>
+        </div>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-3">
+              Select Questions to Show on First Login
+            </label>
+            <p className="text-sm text-gray-500 mb-4">
+              {selectedQuestionIds.size === 0
+                ? 'No questions selected - all active questions will be shown to users'
+                : `${selectedQuestionIds.size} question${selectedQuestionIds.size === 1 ? '' : 's'} selected`}
+            </p>
+            {activeQuestions.length === 0 ? (
+              <div className="bg-gray-50 rounded-lg p-4 text-center text-gray-600">
+                No active questions available. Create questions first.
+              </div>
+            ) : (
+              <div className="border border-gray-200 rounded-lg max-h-96 overflow-y-auto">
+                <div className="divide-y divide-gray-200">
+                  {activeQuestions
+                    .sort((a, b) => a.orderIndex - b.orderIndex)
+                    .map((question) => {
+                      const isSelected = selectedQuestionIds.has(question.questionId);
+                      return (
+                        <label
+                          key={question.questionId}
+                          className={`flex items-start gap-3 p-4 cursor-pointer hover:bg-gray-50 transition-colors ${
+                            isSelected ? 'bg-primary-50' : ''
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={isSelected}
+                            onChange={() => handleToggleQuestion(question.questionId)}
+                            disabled={configLoading || savingConfig}
+                            className="mt-1 w-5 h-5 text-primary-600 border-gray-300 rounded focus:ring-primary-500 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                          />
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2 mb-1">
+                              <span className="text-sm font-semibold text-gray-500">#{question.orderIndex}</span>
+                              <span className="text-sm font-medium text-gray-900">{question.questionText}</span>
+                            </div>
+                            <span className="text-xs text-gray-500">{question.options.length} options</span>
+                          </div>
+                        </label>
+                      );
+                    })}
+                </div>
+              </div>
+            )}
+            <p className="text-sm text-gray-500 mt-3">
+              Total active questions: {activeQuestions.length}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Active Questions */}
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+          <CheckCircle className="w-5 h-5 text-green-600" />
+          Active Questions ({activeQuestions.length})
+        </h3>
+        {activeQuestions.length === 0 ? (
+          <div className="bg-gray-50 rounded-xl p-8 text-center">
+            <p className="text-gray-600">No active questions. Create one to get started.</p>
+          </div>
+        ) : (
+          activeQuestions.map((question) => (
+            <QuestionCard
+              key={question.questionId}
+              question={question}
+              expanded={expandedQuestions.has(question.questionId)}
+              onToggleExpand={() => toggleExpand(question.questionId)}
+              onEdit={() => handleEditQuestion(question)}
+              onDelete={() => handleDeleteQuestion(question.questionId)}
+              onEditOption={handleEditOption}
+              onDeleteOption={handleDeleteOption}
+            />
+          ))
+        )}
+      </div>
+
+      {/* Inactive Questions */}
+      {inactiveQuestions.length > 0 && (
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+            <XCircle className="w-5 h-5 text-gray-400" />
+            Inactive Questions ({inactiveQuestions.length})
+          </h3>
+          {inactiveQuestions.map((question) => (
+            <QuestionCard
+              key={question.questionId}
+              question={question}
+              expanded={expandedQuestions.has(question.questionId)}
+              onToggleExpand={() => toggleExpand(question.questionId)}
+              onEdit={() => handleEditQuestion(question)}
+              onDelete={() => handleDeleteQuestion(question.questionId)}
+              onEditOption={handleEditOption}
+              onDeleteOption={handleDeleteOption}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Editor Modal */}
+      {showEditor && (
+        <QuizQuestionEditor
+          question={editingQuestion}
+          optionId={editingOptionId}
+          onSave={handleSaveQuestion}
+          onSaveOption={editingQuestion && editingOptionId ? 
+            (data) => handleSaveOption(editingQuestion.questionId, editingOptionId, data) : 
+            undefined}
+          onClose={() => {
+            setShowEditor(false);
+            setEditingQuestion(null);
+            setEditingOptionId(null);
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+interface QuestionCardProps {
+  question: QuizQuestionAdmin;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  onEditOption: (questionId: number, optionId: number) => void;
+  onDeleteOption: (questionId: number, optionId: number) => void;
+}
+
+const QuestionCard: React.FC<QuestionCardProps> = ({
+  question,
+  expanded,
+  onToggleExpand,
+  onEdit,
+  onDelete,
+  onEditOption,
+  onDeleteOption,
+}) => {
+  return (
+    <div className={`bg-white rounded-xl border-2 ${question.active ? 'border-gray-200' : 'border-gray-300 opacity-75'}`}>
+      <div className="p-4">
+        <div className="flex items-start justify-between">
+          <div className="flex-1">
+            <div className="flex items-center gap-3 mb-2">
+              <span className="text-sm font-semibold text-gray-500">#{question.orderIndex}</span>
+              {question.active ? (
+                <span className="px-2 py-1 text-xs font-semibold bg-green-100 text-green-700 rounded-full">
+                  Active
+                </span>
+              ) : (
+                <span className="px-2 py-1 text-xs font-semibold bg-gray-100 text-gray-600 rounded-full">
+                  Inactive
+                </span>
+              )}
+            </div>
+            <p className="text-gray-900 font-medium">{question.questionText}</p>
+            <p className="text-sm text-gray-600 mt-1">{question.options.length} options</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onToggleExpand}
+              className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            >
+              {expanded ? (
+                <ChevronUp className="w-5 h-5 text-gray-600" />
+              ) : (
+                <ChevronDown className="w-5 h-5 text-gray-600" />
+              )}
+            </button>
+            <button
+              onClick={onEdit}
+              className="p-2 hover:bg-blue-50 rounded-lg transition-colors"
+            >
+              <Edit className="w-5 h-5 text-blue-600" />
+            </button>
+            <button
+              onClick={onDelete}
+              className="p-2 hover:bg-red-50 rounded-lg transition-colors"
+            >
+              <Trash2 className="w-5 h-5 text-red-600" />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="border-t border-gray-200 p-4 bg-gray-50">
+          <div className="space-y-3">
+            <h4 className="font-semibold text-gray-900">Options:</h4>
+            {question.options.map((option, idx) => (
+              <div
+                key={option.optionId}
+                className="bg-white rounded-lg p-4 border border-gray-200"
+              >
+                <div className="flex items-start justify-between mb-3">
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="text-xs font-semibold text-gray-500">#{option.orderIndex}</span>
+                      <span className="text-sm font-medium text-gray-900">{option.optionText}</span>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => onEditOption(question.questionId, option.optionId)}
+                      className="p-1.5 hover:bg-blue-50 rounded transition-colors"
+                    >
+                      <Edit className="w-4 h-4 text-blue-600" />
+                    </button>
+                    <button
+                      onClick={() => onDeleteOption(question.questionId, option.optionId)}
+                      className="p-1.5 hover:bg-red-50 rounded transition-colors"
+                    >
+                      <Trash2 className="w-4 h-4 text-red-600" />
+                    </button>
+                  </div>
+                </div>
+                <div className="mt-3 pt-3 border-t border-gray-200">
+                  <p className="text-xs font-semibold text-gray-600 mb-2">Role Weights:</p>
+                  <div className="grid grid-cols-7 gap-2">
+                    {ROLE_TYPES.map((role) => (
+                      <div key={role} className="text-center">
+                        <div className="text-xs text-gray-600 mb-1">{ROLE_LABELS[role]}</div>
+                        <div className="text-sm font-semibold text-gray-900">
+                          {option.roleWeights[role]?.toFixed(2) || '0.00'}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default QuizManagement;
+

--- a/frontend/src/components/admin/QuizQuestionEditor.tsx
+++ b/frontend/src/components/admin/QuizQuestionEditor.tsx
@@ -1,0 +1,491 @@
+import React, { useState, useEffect } from 'react';
+import {
+  QuizQuestionAdmin,
+  CreateQuestionRequest,
+  UpdateQuestionRequest,
+  CreateOptionRequest,
+  UpdateOptionRequest,
+  RoleType,
+} from '../../api/quiz';
+import { X, Plus, Trash2, Save } from 'lucide-react';
+
+const ROLE_TYPES: RoleType[] = ['LEADER', 'PLANNER', 'EXPERT', 'CREATIVE', 'COMMUNICATOR', 'TEAM_PLAYER', 'CHALLENGER'];
+const ROLE_LABELS: Record<RoleType, string> = {
+  LEADER: 'Leader',
+  PLANNER: 'Planner',
+  EXPERT: 'Expert',
+  CREATIVE: 'Creative',
+  COMMUNICATOR: 'Communicator',
+  TEAM_PLAYER: 'Team Player',
+  CHALLENGER: 'Challenger',
+};
+
+interface QuizQuestionEditorProps {
+  question: QuizQuestionAdmin | null;
+  optionId: number | null;
+  onSave: (data: CreateQuestionRequest | UpdateQuestionRequest) => void;
+  onSaveOption?: (data: UpdateOptionRequest) => void;
+  onClose: () => void;
+}
+
+const QuizQuestionEditor: React.FC<QuizQuestionEditorProps> = ({
+  question,
+  optionId,
+  onSave,
+  onSaveOption,
+  onClose,
+}) => {
+  const isEditing = question !== null;
+  const isEditingOption = optionId !== null;
+
+  const [questionText, setQuestionText] = useState(question?.questionText || '');
+  const [orderIndex, setOrderIndex] = useState(question?.orderIndex || 1);
+  const [active, setActive] = useState(question?.active ?? true);
+  const [options, setOptions] = useState<CreateOptionRequest[]>(
+    question?.options.map(opt => ({
+      optionText: opt.optionText,
+      orderIndex: opt.orderIndex,
+      roleWeights: { ...opt.roleWeights },
+    })) || [
+      { optionText: '', orderIndex: 1, roleWeights: {} as Record<RoleType, number> },
+      { optionText: '', orderIndex: 2, roleWeights: {} as Record<RoleType, number> },
+      { optionText: '', orderIndex: 3, roleWeights: {} as Record<RoleType, number> },
+      { optionText: '', orderIndex: 4, roleWeights: {} as Record<RoleType, number> },
+    ]
+  );
+
+  const [editingOptionIndex, setEditingOptionIndex] = useState<number | null>(
+    isEditingOption && question
+      ? question.options.findIndex(opt => opt.optionId === optionId)
+      : null
+  );
+
+  // Update state when question prop changes (for editing questions)
+  useEffect(() => {
+    if (question && !isEditingOption) {
+      setQuestionText(question.questionText || '');
+      setOrderIndex(question.orderIndex || 1);
+      setActive(question.active ?? true);
+      setOptions(
+        question.options.map(opt => ({
+          optionText: opt.optionText,
+          orderIndex: opt.orderIndex,
+          roleWeights: { ...opt.roleWeights },
+        }))
+      );
+    }
+  }, [question, isEditingOption]);
+
+  // Update state when editing a specific option
+  useEffect(() => {
+    if (isEditingOption && question && optionId !== null) {
+      const option = question.options.find(opt => opt.optionId === optionId);
+      if (option) {
+        const index = question.options.findIndex(opt => opt.optionId === optionId);
+        setEditingOptionIndex(index);
+        const updatedOptions = [...options];
+        updatedOptions[index] = {
+          optionText: option.optionText,
+          orderIndex: option.orderIndex,
+          roleWeights: { ...option.roleWeights },
+        };
+        setOptions(updatedOptions);
+      }
+    }
+  }, [isEditingOption, question, optionId]);
+
+  const handleAddOption = () => {
+    const newOrderIndex = Math.max(...options.map(o => o.orderIndex), 0) + 1;
+    setOptions([
+      ...options,
+      {
+        optionText: '',
+        orderIndex: newOrderIndex,
+        roleWeights: {} as Record<RoleType, number>,
+      },
+    ]);
+  };
+
+  const handleRemoveOption = (index: number) => {
+    if (options.length <= 1) {
+      alert('At least one option is required');
+      return;
+    }
+    setOptions(options.filter((_, i) => i !== index));
+  };
+
+  const handleUpdateOption = (index: number, field: keyof CreateOptionRequest, value: any) => {
+    const updated = [...options];
+    updated[index] = { ...updated[index], [field]: value };
+    setOptions(updated);
+  };
+
+  const handleUpdateRoleWeight = (optionIndex: number, role: RoleType, weight: number) => {
+    const updated = [...options];
+    const currentWeights = updated[optionIndex].roleWeights || ({} as Record<RoleType, number>);
+    updated[optionIndex] = {
+      ...updated[optionIndex],
+      roleWeights: { ...currentWeights, [role]: Math.max(0, Math.min(1, weight)) },
+    };
+    setOptions(updated);
+  };
+
+  const handleSave = () => {
+    // If editing a single option, use onSaveOption
+    if (isEditingOption && editingOptionIndex !== null && onSaveOption) {
+      const editingOption = options[editingOptionIndex];
+      
+      // Validation
+      if (!editingOption.optionText.trim()) {
+        alert('Option text is required');
+        return;
+      }
+
+      const hasWeight = Object.values(editingOption.roleWeights || {}).some(w => w > 0);
+      if (!hasWeight) {
+        alert('Option must have at least one role weight > 0');
+        return;
+      }
+
+      const updateData: UpdateOptionRequest = {
+        optionText: editingOption.optionText,
+        orderIndex: editingOption.orderIndex,
+        roleWeights: editingOption.roleWeights,
+      };
+      onSaveOption(updateData);
+      return;
+    }
+
+    // If editing a question (not an option), validate question fields and options
+    if (isEditing) {
+      // Validation for question update
+      if (!questionText.trim()) {
+        alert('Question text is required');
+        return;
+      }
+
+      // Validate options if they exist
+      if (options && options.length > 0) {
+        for (let i = 0; i < options.length; i++) {
+          const opt = options[i];
+          if (!opt.optionText.trim()) {
+            alert(`Option ${i + 1} text is required`);
+            return;
+          }
+
+          const hasWeight = Object.values(opt.roleWeights || {}).some(w => w > 0);
+          if (!hasWeight) {
+            alert(`Option ${i + 1} must have at least one role weight > 0`);
+            return;
+          }
+        }
+      }
+
+      const updateData: UpdateQuestionRequest = {
+        questionText,
+        orderIndex,
+        active,
+        options: options.map(opt => ({
+          optionText: opt.optionText,
+          orderIndex: opt.orderIndex,
+          roleWeights: opt.roleWeights,
+        })),
+      };
+      onSave(updateData);
+      return;
+    }
+
+    // Creating a new question - validate everything including options
+    if (!questionText.trim()) {
+      alert('Question text is required');
+      return;
+    }
+
+    if (options.length === 0) {
+      alert('At least one option is required');
+      return;
+    }
+
+    for (let i = 0; i < options.length; i++) {
+      const opt = options[i];
+      if (!opt.optionText.trim()) {
+        alert(`Option ${i + 1} text is required`);
+        return;
+      }
+
+      const hasWeight = Object.values(opt.roleWeights || {}).some(w => w > 0);
+      if (!hasWeight) {
+        alert(`Option ${i + 1} must have at least one role weight > 0`);
+        return;
+      }
+    }
+
+    const createData: CreateQuestionRequest = {
+      questionText,
+      orderIndex,
+      options: options.map(opt => ({
+        optionText: opt.optionText,
+        orderIndex: opt.orderIndex,
+        roleWeights: opt.roleWeights,
+      })),
+    };
+    onSave(createData);
+  };
+
+  if (isEditingOption && editingOptionIndex !== null) {
+    const editingOption = options[editingOptionIndex];
+    return (
+      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="bg-white rounded-xl shadow-xl max-w-4xl w-full max-h-[90vh] overflow-y-auto">
+          <div className="sticky top-0 bg-white border-b border-gray-200 p-6 flex items-center justify-between">
+            <h2 className="text-2xl font-bold text-gray-900">Edit Option</h2>
+            <button
+              onClick={onClose}
+              className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            >
+              <X className="w-6 h-6 text-gray-600" />
+            </button>
+          </div>
+
+          <div className="p-6 space-y-6">
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-2">
+                Option Text
+              </label>
+              <input
+                type="text"
+                value={editingOption.optionText}
+                onChange={(e) => handleUpdateOption(editingOptionIndex, 'optionText', e.target.value)}
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                placeholder="Enter option text..."
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-2">
+                Order Index
+              </label>
+              <input
+                type="number"
+                value={editingOption.orderIndex}
+                onChange={(e) => handleUpdateOption(editingOptionIndex, 'orderIndex', parseInt(e.target.value) || 0)}
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                min="1"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-4">
+                Role Weights (0.0 to 1.0)
+              </label>
+              <div className="grid grid-cols-7 gap-4">
+                {ROLE_TYPES.map((role) => (
+                  <div key={role}>
+                    <label className="block text-xs font-medium text-gray-600 mb-1">
+                      {ROLE_LABELS[role]}
+                    </label>
+                    <input
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      max="1"
+                      value={editingOption.roleWeights[role] || 0}
+                      onChange={(e) =>
+                        handleUpdateRoleWeight(
+                          editingOptionIndex,
+                          role,
+                          parseFloat(e.target.value) || 0
+                        )
+                      }
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm"
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="sticky bottom-0 bg-gray-50 border-t border-gray-200 p-6 flex items-center justify-end gap-3">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors flex items-center gap-2"
+            >
+              <Save className="w-4 h-4" />
+              Save Option
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-xl max-w-5xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="sticky top-0 bg-white border-b border-gray-200 p-6 flex items-center justify-between">
+          <h2 className="text-2xl font-bold text-gray-900">
+            {isEditing ? 'Edit Question' : 'Create Question'}
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            <X className="w-6 h-6 text-gray-600" />
+          </button>
+        </div>
+
+        <div className="p-6 space-y-6">
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-2">
+              Question Text
+            </label>
+            <textarea
+              value={questionText}
+              onChange={(e) => setQuestionText(e.target.value)}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              placeholder="Enter question text..."
+              rows={3}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-2">
+                Order Index
+              </label>
+              <input
+                type="number"
+                value={orderIndex}
+                onChange={(e) => setOrderIndex(parseInt(e.target.value) || 1)}
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                min="1"
+              />
+            </div>
+
+            {isEditing && (
+              <div className="flex items-center gap-3 pt-8">
+                <input
+                  type="checkbox"
+                  id="active"
+                  checked={active}
+                  onChange={(e) => setActive(e.target.checked)}
+                  className="w-5 h-5 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
+                />
+                <label htmlFor="active" className="text-sm font-semibold text-gray-700">
+                  Active
+                </label>
+              </div>
+            )}
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between mb-4">
+              <label className="block text-sm font-semibold text-gray-700">Options</label>
+              <button
+                onClick={handleAddOption}
+                className="flex items-center gap-2 px-3 py-1.5 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
+              >
+                <Plus className="w-4 h-4" />
+                Add Option
+              </button>
+            </div>
+
+            <div className="space-y-4">
+              {options.map((option, index) => (
+                <div key={index} className="border border-gray-200 rounded-lg p-4 bg-gray-50">
+                  <div className="flex items-start justify-between mb-3">
+                    <div className="flex-1 grid grid-cols-2 gap-4">
+                      <div>
+                        <label className="block text-xs font-medium text-gray-600 mb-1">
+                          Option Text
+                        </label>
+                        <input
+                          type="text"
+                          value={option.optionText}
+                          onChange={(e) => handleUpdateOption(index, 'optionText', e.target.value)}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm"
+                          placeholder="Enter option text..."
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs font-medium text-gray-600 mb-1">
+                          Order Index
+                        </label>
+                        <input
+                          type="number"
+                          value={option.orderIndex}
+                          onChange={(e) => handleUpdateOption(index, 'orderIndex', parseInt(e.target.value) || 0)}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm"
+                          min="1"
+                        />
+                      </div>
+                    </div>
+                    {options.length > 1 && (
+                      <button
+                        onClick={() => handleRemoveOption(index)}
+                        className="ml-3 p-2 hover:bg-red-50 rounded-lg transition-colors"
+                      >
+                        <Trash2 className="w-4 h-4 text-red-600" />
+                      </button>
+                    )}
+                  </div>
+
+                  <div className="mt-4 pt-4 border-t border-gray-200">
+                    <label className="block text-xs font-semibold text-gray-700 mb-3">
+                      Role Weights (0.0 to 1.0)
+                    </label>
+                    <div className="grid grid-cols-7 gap-2">
+                      {ROLE_TYPES.map((role) => (
+                        <div key={role}>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">
+                            {ROLE_LABELS[role]}
+                          </label>
+                          <input
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            max="1"
+                            value={option.roleWeights[role] || 0}
+                            onChange={(e) =>
+                              handleUpdateRoleWeight(index, role, parseFloat(e.target.value) || 0)
+                            }
+                            className="w-full px-2 py-1.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-xs"
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="sticky bottom-0 bg-gray-50 border-t border-gray-200 p-6 flex items-center justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors flex items-center gap-2"
+          >
+            <Save className="w-4 h-4" />
+            {isEditing ? 'Update Question' : 'Create Question'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QuizQuestionEditor;
+

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -52,7 +52,9 @@ import {
   Ban,
   Clock,
   FileText,
+  HelpCircle,
 } from 'lucide-react';
+import QuizManagement from '../components/admin/QuizManagement';
 
 const Admin: React.FC = () => {
   const { isAdmin, user: currentUser } = useAuth();
@@ -68,7 +70,7 @@ const Admin: React.FC = () => {
     }
     return defaultMessage;
   };
-  const [activeTab, setActiveTab] = useState<'overview' | 'users' | 'courses' | 'groups'>('overview');
+  const [activeTab, setActiveTab] = useState<'overview' | 'users' | 'courses' | 'groups' | 'quiz'>('overview');
   const [users, setUsers] = useState<User[]>([]);
   const [courses, setCourses] = useState<Course[]>([]);
   const [groups, setGroups] = useState<StudyGroup[]>([]);
@@ -994,6 +996,7 @@ const Admin: React.FC = () => {
               { id: 'users', label: 'Users', icon: Users },
               { id: 'courses', label: 'Courses', icon: GraduationCap },
               { id: 'groups', label: 'Groups', icon: BookOpen },
+              { id: 'quiz', label: 'Quiz Questions', icon: HelpCircle },
             ].map((tab) => (
               <button
                 key={tab.id}
@@ -1591,6 +1594,10 @@ const Admin: React.FC = () => {
                 </table>
               </div>
             </div>
+          )}
+
+          {activeTab === 'quiz' && (
+            <QuizManagement />
           )}
         </div>
       </div>

--- a/src/main/java/com/studybuddy/config/DataInitializer.java
+++ b/src/main/java/com/studybuddy/config/DataInitializer.java
@@ -140,11 +140,12 @@ public class DataInitializer implements CommandLineRunner {
         }
         
         // Step 2: Create 20 Quiz Questions (only if missing)
+        // NOTE: This is a fallback for initial seeding. Admins should manage questions via the Admin Panel.
         if (quizQuestionRepository.count() == 0) {
-            log.info("Creating quiz questions...");
+            log.info("Creating quiz questions (fallback seeding - admins should manage via Admin Panel)...");
             createQuizQuestions();
         } else {
-            log.info("Quiz questions already exist. Skipping.");
+            log.info("Quiz questions already exist. Skipping. Admins can manage questions via Admin Panel.");
         }
         
         // Step 3: Create 50 Students with profiles (only if not many users exist yet)

--- a/src/main/java/com/studybuddy/controller/QuizAdminController.java
+++ b/src/main/java/com/studybuddy/controller/QuizAdminController.java
@@ -1,0 +1,151 @@
+package com.studybuddy.controller;
+
+import com.studybuddy.dto.QuizDto;
+import com.studybuddy.service.QuizService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * Admin Controller for managing quiz questions and options.
+ * Only admins can create, edit, and delete quiz questions.
+ */
+@RestController
+@RequestMapping("/api/admin/quiz")
+@PreAuthorize("hasRole('ADMIN')")
+@RequiredArgsConstructor
+@Slf4j
+public class QuizAdminController {
+    
+    private final QuizService quizService;
+    
+    /**
+     * GET /api/admin/quiz/questions
+     * Get all quiz questions (including inactive) for admin management.
+     */
+    @GetMapping("/questions")
+    public ResponseEntity<List<QuizDto.QuestionAdminResponse>> getAllQuestions() {
+        log.info("Admin fetching all quiz questions");
+        List<QuizDto.QuestionAdminResponse> questions = quizService.getAllQuestionsForAdmin();
+        return ResponseEntity.ok(questions);
+    }
+    
+    /**
+     * GET /api/admin/quiz/questions/{id}
+     * Get a single question with full details.
+     */
+    @GetMapping("/questions/{id}")
+    public ResponseEntity<QuizDto.QuestionAdminResponse> getQuestion(@PathVariable Long id) {
+        log.info("Admin fetching question {}", id);
+        QuizDto.QuestionAdminResponse question = quizService.getQuestionForAdmin(id);
+        return ResponseEntity.ok(question);
+    }
+    
+    /**
+     * POST /api/admin/quiz/questions
+     * Create a new quiz question with options.
+     */
+    @PostMapping("/questions")
+    public ResponseEntity<QuizDto.QuestionAdminResponse> createQuestion(
+            @Valid @RequestBody QuizDto.CreateQuestionRequest request) {
+        log.info("Admin creating new quiz question");
+        QuizDto.QuestionAdminResponse question = quizService.createQuestion(request);
+        return ResponseEntity.ok(question);
+    }
+    
+    /**
+     * PUT /api/admin/quiz/questions/{id}
+     * Update a quiz question.
+     */
+    @PutMapping("/questions/{id}")
+    public ResponseEntity<QuizDto.QuestionAdminResponse> updateQuestion(
+            @PathVariable Long id,
+            @Valid @RequestBody QuizDto.UpdateQuestionRequest request) {
+        log.info("Admin updating question {}", id);
+        QuizDto.QuestionAdminResponse question = quizService.updateQuestion(id, request);
+        return ResponseEntity.ok(question);
+    }
+    
+    /**
+     * DELETE /api/admin/quiz/questions/{id}
+     * Delete (deactivate) a quiz question.
+     */
+    @DeleteMapping("/questions/{id}")
+    public ResponseEntity<Void> deleteQuestion(@PathVariable Long id) {
+        log.info("Admin deleting question {}", id);
+        quizService.deleteQuestion(id);
+        return ResponseEntity.noContent().build();
+    }
+    
+    /**
+     * PUT /api/admin/quiz/questions/{questionId}/options/{optionId}
+     * Update a quiz option.
+     */
+    @PutMapping("/questions/{questionId}/options/{optionId}")
+    public ResponseEntity<QuizDto.OptionAdminResponse> updateOption(
+            @PathVariable Long questionId,
+            @PathVariable Long optionId,
+            @Valid @RequestBody QuizDto.UpdateOptionRequest request) {
+        log.info("Admin updating option {} for question {}", optionId, questionId);
+        QuizDto.OptionAdminResponse option = quizService.updateOption(questionId, optionId, request);
+        return ResponseEntity.ok(option);
+    }
+    
+    /**
+     * DELETE /api/admin/quiz/questions/{questionId}/options/{optionId}
+     * Delete a quiz option.
+     */
+    @DeleteMapping("/questions/{questionId}/options/{optionId}")
+    public ResponseEntity<Void> deleteOption(
+            @PathVariable Long questionId,
+            @PathVariable Long optionId) {
+        log.info("Admin deleting option {} from question {}", optionId, questionId);
+        quizService.deleteOption(questionId, optionId);
+        return ResponseEntity.noContent().build();
+    }
+    
+    /**
+     * GET /api/admin/quiz/config
+     * Get quiz configuration.
+     */
+    @GetMapping("/config")
+    public ResponseEntity<com.studybuddy.model.QuizConfig> getConfig() {
+        log.info("Admin fetching quiz configuration");
+        com.studybuddy.model.QuizConfig config = quizService.getQuizConfig();
+        return ResponseEntity.ok(config);
+    }
+    
+    /**
+     * PUT /api/admin/quiz/config
+     * Update quiz configuration.
+     */
+    @PutMapping("/config")
+    public ResponseEntity<com.studybuddy.model.QuizConfig> updateConfig(
+            @RequestBody QuizConfigUpdateRequest request) {
+        log.info("Admin updating quiz configuration: {} questions selected", 
+                request.getSelectedQuestionIds() != null ? request.getSelectedQuestionIds().size() : 0);
+        com.studybuddy.model.QuizConfig config = quizService.updateQuizConfig(request.getSelectedQuestionIds());
+        return ResponseEntity.ok(config);
+    }
+    
+    /**
+     * Request DTO for updating quiz config
+     */
+    public static class QuizConfigUpdateRequest {
+        private java.util.List<Long> selectedQuestionIds;
+        
+        public java.util.List<Long> getSelectedQuestionIds() {
+            return selectedQuestionIds;
+        }
+        
+        public void setSelectedQuestionIds(java.util.List<Long> selectedQuestionIds) {
+            this.selectedQuestionIds = selectedQuestionIds;
+        }
+    }
+}
+

--- a/src/main/java/com/studybuddy/dto/QuizDto.java
+++ b/src/main/java/com/studybuddy/dto/QuizDto.java
@@ -114,4 +114,59 @@ public class QuizDto {
         @NotEmpty(message = "Role weights are required")
         private Map<RoleType, Double> roleWeights;
     }
+    
+    // ==================== ADMIN DTOs ====================
+    
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QuestionAdminResponse {
+        private Long questionId;
+        private String questionText;
+        private Integer orderIndex;
+        private Boolean active;
+        private List<OptionAdminResponse> options;
+    }
+    
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OptionAdminResponse {
+        private Long optionId;
+        private String optionText;
+        private Integer orderIndex;
+        private Map<RoleType, Double> roleWeights; // Admin can see role weights
+    }
+    
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateQuestionRequest {
+        @NotBlank(message = "Question text is required")
+        private String questionText;
+        
+        @NotNull
+        private Integer orderIndex;
+        
+        private Boolean active;
+        
+        // Optional: if provided, will update all options
+        private List<UpdateOptionRequest> options;
+    }
+    
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateOptionRequest {
+        @NotBlank(message = "Option text is required")
+        private String optionText;
+        
+        @NotNull
+        private Integer orderIndex;
+        
+        @NotEmpty(message = "Role weights are required")
+        private Map<RoleType, Double> roleWeights;
+    }
 }

--- a/src/main/java/com/studybuddy/model/QuizConfig.java
+++ b/src/main/java/com/studybuddy/model/QuizConfig.java
@@ -1,0 +1,48 @@
+package com.studybuddy.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Quiz Configuration Entity
+ * Stores system-wide quiz settings
+ */
+@Entity
+@Table(name = "quiz_config")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizConfig {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    /**
+     * Selected question IDs to show to users on first login.
+     * If null or empty, all active questions will be shown.
+     * Questions are shown in the order specified in this list.
+     */
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "quiz_config_selected_questions", 
+                     joinColumns = @JoinColumn(name = "config_id"))
+    @Column(name = "question_id")
+    @Builder.Default
+    private List<Long> selectedQuestionIds = new ArrayList<>();
+    
+    /**
+     * Since we only need one config record, we'll use a singleton pattern.
+     * This field ensures only one config exists.
+     */
+    @Column(unique = true, nullable = false)
+    @Builder.Default
+    private String configKey = "DEFAULT";
+}
+

--- a/src/main/java/com/studybuddy/repository/QuizConfigRepository.java
+++ b/src/main/java/com/studybuddy/repository/QuizConfigRepository.java
@@ -1,0 +1,25 @@
+package com.studybuddy.repository;
+
+import com.studybuddy.model.QuizConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface QuizConfigRepository extends JpaRepository<QuizConfig, Long> {
+    
+    Optional<QuizConfig> findByConfigKey(String configKey);
+    
+    default QuizConfig getDefaultConfig() {
+        return findByConfigKey("DEFAULT")
+                .orElseGet(() -> {
+                    QuizConfig config = QuizConfig.builder()
+                            .configKey("DEFAULT")
+                            .selectedQuestionIds(new java.util.ArrayList<>()) // empty means show all
+                            .build();
+                    return save(config);
+                });
+    }
+}
+

--- a/src/main/java/com/studybuddy/service/QuizService.java
+++ b/src/main/java/com/studybuddy/service/QuizService.java
@@ -1,24 +1,33 @@
 package com.studybuddy.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.studybuddy.dto.QuizDto;
+import com.studybuddy.model.AdminAuditLog;
 import com.studybuddy.model.CharacteristicProfile;
 import com.studybuddy.model.QuizOption;
 import com.studybuddy.model.QuizQuestion;
 import com.studybuddy.model.QuizStatus;
 import com.studybuddy.model.RoleType;
 import com.studybuddy.model.User;
+import com.studybuddy.repository.AdminAuditLogRepository;
 import com.studybuddy.repository.CharacteristicProfileRepository;
 import com.studybuddy.repository.QuizAnswerRepository;
 import com.studybuddy.repository.QuizOptionRepository;
 import com.studybuddy.repository.QuizQuestionRepository;
+import com.studybuddy.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -30,19 +39,49 @@ public class QuizService {
     private final QuizOptionRepository optionRepository;
     private final CharacteristicProfileRepository profileRepository;
     private final QuizAnswerRepository answerRepository;
+    private final AdminAuditLogRepository auditLogRepository;
+    private final UserRepository userRepository;
+    private final com.studybuddy.repository.QuizConfigRepository quizConfigRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
     
     /**
      * Get all active quiz questions.
-     * Returns all questions (not filtered by answered status) so users can always see the first question.
+     * Returns questions based on admin configuration (selected question IDs).
+     * If no questions are selected, returns all active questions.
      * The submit endpoint prevents re-answering already answered questions.
      */
     @Transactional(readOnly = true)
     public List<QuizDto.QuestionResponse> getQuiz(User user) {
         List<QuizQuestion> allQuestions = questionRepository.findAllActiveWithOptions();
         
-        log.info("User {} - returning {} active quiz questions", user.getId(), allQuestions.size());
+        // Get configured selected question IDs
+        com.studybuddy.model.QuizConfig config = quizConfigRepository.getDefaultConfig();
+        List<Long> selectedQuestionIds = config.getSelectedQuestionIds();
         
-        // Return all questions (frontend will filter to show only first question)
+        // If configured with specific question IDs, filter to only those questions
+        if (selectedQuestionIds != null && !selectedQuestionIds.isEmpty()) {
+            // Create a map for quick lookup
+            Map<Long, QuizQuestion> questionMap = allQuestions.stream()
+                    .collect(Collectors.toMap(QuizQuestion::getId, q -> q));
+            
+            // Filter to only selected questions, maintaining the order from config
+            List<QuizQuestion> selectedQuestions = new java.util.ArrayList<>();
+            for (Long questionId : selectedQuestionIds) {
+                QuizQuestion question = questionMap.get(questionId);
+                if (question != null && question.getActive()) {
+                    selectedQuestions.add(question);
+                }
+            }
+            
+            allQuestions = selectedQuestions;
+            log.info("User {} - returning {} of {} active quiz questions (filtered by selected IDs)", 
+                    user.getId(), allQuestions.size(), questionRepository.findAllActiveWithOptions().size());
+        } else {
+            log.info("User {} - returning {} active quiz questions (no selection configured, showing all)", 
+                    user.getId(), allQuestions.size());
+        }
+        
+        // Return questions (frontend will filter to show only first question)
         return allQuestions.stream()
                 .map(this::mapToQuestionResponse)
                 .collect(Collectors.toList());
@@ -307,5 +346,346 @@ public class QuizService {
                 .orderIndex(question.getOrderIndex())
                 .options(options)
                 .build();
+    }
+    
+    // ==================== ADMIN METHODS ====================
+    
+    /**
+     * Get all quiz questions (including inactive) for admin management.
+     */
+    @Transactional(readOnly = true)
+    public List<QuizDto.QuestionAdminResponse> getAllQuestionsForAdmin() {
+        List<QuizQuestion> allQuestions = questionRepository.findAll();
+        
+        return allQuestions.stream()
+                .sorted((a, b) -> Integer.compare(
+                    a.getOrderIndex() != null ? a.getOrderIndex() : 0,
+                    b.getOrderIndex() != null ? b.getOrderIndex() : 0
+                ))
+                .map(this::mapToQuestionAdminResponse)
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * Get a single question with full details for admin.
+     */
+    @Transactional(readOnly = true)
+    public QuizDto.QuestionAdminResponse getQuestionForAdmin(Long questionId) {
+        QuizQuestion question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new IllegalArgumentException("Question not found: " + questionId));
+        return mapToQuestionAdminResponse(question);
+    }
+    
+    /**
+     * Create a new quiz question with options.
+     */
+    @Transactional
+    public QuizDto.QuestionAdminResponse createQuestion(QuizDto.CreateQuestionRequest request) {
+        QuizQuestion question = QuizQuestion.builder()
+                .questionText(request.getQuestionText())
+                .orderIndex(request.getOrderIndex())
+                .active(true)
+                .options(new java.util.ArrayList<>())
+                .build();
+        
+        // Create options
+        for (QuizDto.CreateOptionRequest optReq : request.getOptions()) {
+            QuizOption option = QuizOption.builder()
+                    .optionText(optReq.getOptionText())
+                    .orderIndex(optReq.getOrderIndex())
+                    .roleWeights(new HashMap<>(optReq.getRoleWeights()))
+                    .build();
+            question.addOption(option);
+        }
+        
+        question = questionRepository.save(question);
+        log.info("Created quiz question {} with {} options", question.getId(), question.getOptions().size());
+        
+        // Log audit action
+        logAuditAction("QUIZ_QUESTION_CREATE", "QUIZ_QUESTION", question.getId(), 
+                String.format("Created new quiz question: '%s'", request.getQuestionText()),
+                Map.of(
+                    "questionText", request.getQuestionText(),
+                    "orderIndex", request.getOrderIndex(),
+                    "optionsCount", request.getOptions().size()
+                ));
+        
+        return mapToQuestionAdminResponse(question);
+    }
+    
+    /**
+     * Update a quiz question.
+     */
+    @Transactional
+    public QuizDto.QuestionAdminResponse updateQuestion(Long questionId, QuizDto.UpdateQuestionRequest request) {
+        QuizQuestion question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new IllegalArgumentException("Question not found: " + questionId));
+        
+        // Store old values for audit log
+        String oldQuestionText = question.getQuestionText();
+        Integer oldOrderIndex = question.getOrderIndex();
+        Boolean oldActive = question.getActive();
+        
+        question.setQuestionText(request.getQuestionText());
+        question.setOrderIndex(request.getOrderIndex());
+        if (request.getActive() != null) {
+            question.setActive(request.getActive());
+        }
+        
+        // Update options if provided
+        if (request.getOptions() != null && !request.getOptions().isEmpty()) {
+            // Update existing options by orderIndex, or create new ones
+            Map<Integer, QuizOption> existingOptionsByOrder = question.getOptions().stream()
+                    .collect(Collectors.toMap(
+                            opt -> opt.getOrderIndex() != null ? opt.getOrderIndex() : 0,
+                            opt -> opt,
+                            (a, b) -> a // In case of duplicates, keep first
+                    ));
+            
+            // Track which order indices are being updated
+            Set<Integer> updatedOrderIndices = new HashSet<>();
+            
+            for (QuizDto.UpdateOptionRequest optReq : request.getOptions()) {
+                Integer orderIndex = optReq.getOrderIndex();
+                updatedOrderIndices.add(orderIndex);
+                
+                QuizOption existingOption = existingOptionsByOrder.get(orderIndex);
+                if (existingOption != null) {
+                    // Update existing option
+                    existingOption.setOptionText(optReq.getOptionText());
+                    existingOption.setOrderIndex(optReq.getOrderIndex());
+                    existingOption.setRoleWeights(new HashMap<>(optReq.getRoleWeights()));
+                } else {
+                    // Create new option
+                    QuizOption newOption = QuizOption.builder()
+                            .optionText(optReq.getOptionText())
+                            .orderIndex(optReq.getOrderIndex())
+                            .roleWeights(new HashMap<>(optReq.getRoleWeights()))
+                            .build();
+                    question.addOption(newOption);
+                }
+            }
+            
+            // Remove options that are no longer in the request (by orderIndex)
+            question.getOptions().removeIf(opt -> 
+                    opt.getOrderIndex() != null && !updatedOrderIndices.contains(opt.getOrderIndex()));
+        }
+        
+        question = questionRepository.save(question);
+        log.info("Updated quiz question {}", questionId);
+        
+        // Log audit action
+        logAuditAction("QUIZ_QUESTION_UPDATE", "QUIZ_QUESTION", questionId, 
+                String.format("Updated question: '%s' -> '%s'", oldQuestionText, request.getQuestionText()),
+                Map.of(
+                    "oldQuestionText", oldQuestionText,
+                    "newQuestionText", request.getQuestionText(),
+                    "oldOrderIndex", oldOrderIndex,
+                    "newOrderIndex", request.getOrderIndex(),
+                    "oldActive", oldActive,
+                    "newActive", request.getActive() != null ? request.getActive() : oldActive,
+                    "optionsUpdated", request.getOptions() != null && !request.getOptions().isEmpty()
+                ));
+        
+        return mapToQuestionAdminResponse(question);
+    }
+    
+    /**
+     * Delete (deactivate) a quiz question.
+     */
+    @Transactional
+    public void deleteQuestion(Long questionId) {
+        QuizQuestion question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new IllegalArgumentException("Question not found: " + questionId));
+        
+        String questionText = question.getQuestionText();
+        int optionsCount = question.getOptions().size();
+        
+        // Soft delete by setting active = false
+        question.setActive(false);
+        questionRepository.save(question);
+        log.info("Deactivated quiz question {}", questionId);
+        
+        // Log audit action
+        logAuditAction("QUIZ_QUESTION_DELETE", "QUIZ_QUESTION", questionId, 
+                String.format("Deactivated quiz question: '%s'", questionText),
+                Map.of(
+                    "questionText", questionText,
+                    "optionsCount", optionsCount
+                ));
+    }
+    
+    /**
+     * Update a quiz option.
+     */
+    @Transactional
+    public QuizDto.OptionAdminResponse updateOption(Long questionId, Long optionId, QuizDto.UpdateOptionRequest request) {
+        QuizQuestion question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new IllegalArgumentException("Question not found: " + questionId));
+        
+        QuizOption option = question.getOptions().stream()
+                .filter(opt -> opt.getId().equals(optionId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Option not found: " + optionId));
+        
+        String oldOptionText = option.getOptionText();
+        
+        option.setOptionText(request.getOptionText());
+        option.setOrderIndex(request.getOrderIndex());
+        option.setRoleWeights(new HashMap<>(request.getRoleWeights()));
+        
+        optionRepository.save(option);
+        log.info("Updated option {} for question {}", optionId, questionId);
+        
+        // Log audit action
+        logAuditAction("QUIZ_OPTION_UPDATE", "QUIZ_OPTION", optionId, 
+                String.format("Updated option for question %d: '%s' -> '%s'", questionId, oldOptionText, request.getOptionText()),
+                Map.of(
+                    "questionId", questionId,
+                    "oldOptionText", oldOptionText,
+                    "newOptionText", request.getOptionText(),
+                    "orderIndex", request.getOrderIndex()
+                ));
+        
+        return mapToOptionAdminResponse(option);
+    }
+    
+    /**
+     * Delete a quiz option.
+     */
+    @Transactional
+    public void deleteOption(Long questionId, Long optionId) {
+        QuizQuestion question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new IllegalArgumentException("Question not found: " + questionId));
+        
+        QuizOption option = question.getOptions().stream()
+                .filter(opt -> opt.getId().equals(optionId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Option not found: " + optionId));
+        
+        String optionText = option.getOptionText();
+        
+        // Remove from question's options list
+        question.getOptions().remove(option);
+        questionRepository.save(question);
+        
+        // Delete the option
+        optionRepository.delete(option);
+        log.info("Deleted option {} from question {}", optionId, questionId);
+        
+        // Log audit action
+        logAuditAction("QUIZ_OPTION_DELETE", "QUIZ_OPTION", optionId, 
+                String.format("Deleted option from question %d: '%s'", questionId, optionText),
+                Map.of(
+                    "questionId", questionId,
+                    "optionText", optionText
+                ));
+    }
+    
+    /**
+     * Log admin action to audit log.
+     */
+    private void logAuditAction(String actionType, String targetType, Long targetId, String reason, Map<String, Object> metadata) {
+        try {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth != null && auth.isAuthenticated()) {
+                User admin = userRepository.findByUsername(auth.getName()).orElse(null);
+                if (admin != null) {
+                    AdminAuditLog log = new AdminAuditLog();
+                    log.setAdminUserId(admin.getId());
+                    log.setActionType(actionType);
+                    log.setTargetType(targetType);
+                    log.setTargetId(targetId);
+                    log.setReason(reason);
+                    
+                    if (metadata != null && !metadata.isEmpty()) {
+                        try {
+                            log.setMetadata(objectMapper.writeValueAsString(metadata));
+                        } catch (JsonProcessingException e) {
+                            log.setMetadata(metadata.toString());
+                        }
+                    }
+                    
+                    auditLogRepository.save(log);
+                }
+            }
+        } catch (Exception e) {
+            // Don't fail the operation if audit logging fails
+            log.warn("Failed to log audit action: {}", e.getMessage());
+        }
+    }
+    
+    private QuizDto.QuestionAdminResponse mapToQuestionAdminResponse(QuizQuestion question) {
+        List<QuizDto.OptionAdminResponse> options = question.getOptions().stream()
+                .sorted((a, b) -> Integer.compare(
+                    a.getOrderIndex() != null ? a.getOrderIndex() : 0,
+                    b.getOrderIndex() != null ? b.getOrderIndex() : 0
+                ))
+                .map(this::mapToOptionAdminResponse)
+                .collect(Collectors.toList());
+        
+        return QuizDto.QuestionAdminResponse.builder()
+                .questionId(question.getId())
+                .questionText(question.getQuestionText())
+                .orderIndex(question.getOrderIndex())
+                .active(question.getActive())
+                .options(options)
+                .build();
+    }
+    
+    private QuizDto.OptionAdminResponse mapToOptionAdminResponse(QuizOption option) {
+        return QuizDto.OptionAdminResponse.builder()
+                .optionId(option.getId())
+                .optionText(option.getOptionText())
+                .orderIndex(option.getOrderIndex())
+                .roleWeights(new HashMap<>(option.getRoleWeights()))
+                .build();
+    }
+    
+    // ==================== QUIZ CONFIG METHODS ====================
+    
+    /**
+     * Get quiz configuration.
+     */
+    @Transactional(readOnly = true)
+    public com.studybuddy.model.QuizConfig getQuizConfig() {
+        return quizConfigRepository.getDefaultConfig();
+    }
+    
+    /**
+     * Update quiz configuration.
+     */
+    @Transactional
+    public com.studybuddy.model.QuizConfig updateQuizConfig(List<Long> selectedQuestionIds) {
+        com.studybuddy.model.QuizConfig config = quizConfigRepository.getDefaultConfig();
+        
+        // Validate that all selected question IDs exist and are active
+        if (selectedQuestionIds != null && !selectedQuestionIds.isEmpty()) {
+            List<QuizQuestion> allActiveQuestions = questionRepository.findAllActiveWithOptions();
+            Set<Long> activeQuestionIds = allActiveQuestions.stream()
+                    .map(QuizQuestion::getId)
+                    .collect(Collectors.toSet());
+            
+            // Filter out invalid question IDs
+            List<Long> validQuestionIds = selectedQuestionIds.stream()
+                    .filter(activeQuestionIds::contains)
+                    .collect(Collectors.toList());
+            
+            config.setSelectedQuestionIds(validQuestionIds);
+            log.info("Updated quiz config: selected {} question IDs", validQuestionIds.size());
+        } else {
+            config.setSelectedQuestionIds(new java.util.ArrayList<>());
+            log.info("Updated quiz config: no questions selected (will show all)");
+        }
+        
+        config = quizConfigRepository.save(config);
+        
+        // Log audit action
+        logAuditAction("QUIZ_CONFIG_UPDATE", "QUIZ_CONFIG", config.getId(), 
+                String.format("Updated quiz configuration: %d questions selected", 
+                        config.getSelectedQuestionIds() != null ? config.getSelectedQuestionIds().size() : 0),
+                Map.of("selectedQuestionIds", config.getSelectedQuestionIds() != null ? config.getSelectedQuestionIds() : List.of()));
+        
+        return config;
     }
 }


### PR DESCRIPTION
Add admin-managed quiz questions and remove hardcoded quiz configuration

- Moved quiz questions from hardcoded DataInitializer to admin-managed entities
- Added admin CRUD capabilities for quiz questions and options
- Preserved existing quiz flow, scoring logic, and role-weighting behavior
- Kept DataInitializer as a fallback for initial seeding only
